### PR TITLE
call lint-fix before lint so we fix autofixable errors

### DIFF
--- a/calorify-api/package.json
+++ b/calorify-api/package.json
@@ -4,10 +4,10 @@
     "description": "Calorify API",
     "main": "index.js",
     "scripts": {
-    "prestart": "npm run lint ,npm run lint-fix, npm install",
-    "lint": "eslint **/*.js",
-    "lint-fix": "eslint --fix **/*.js",
-    "start": "node index.js"
+        "prestart": "npm run lint-fix ,npm run lint, npm install",
+        "lint": "eslint **/*.js",
+        "lint-fix": "eslint --fix **/*.js",
+        "start": "node index.js"
     },
     "keywords": [
         "swagger"
@@ -18,12 +18,12 @@
         "express": "^4.15.4",
         "js-yaml": "^3.3.0",
         "swagger-tools": "0.10.1"
-  },
-  "devDependencies": {
-    "eslint": "^2.13.1"
-  },
-  "env": {
-    "browser": true,
-    "node": true
+    },
+    "devDependencies": {
+        "eslint": "^2.13.1"
+    },
+    "env": {
+        "browser": true,
+        "node": true
     }
 }


### PR DESCRIPTION
This is so that when we do `npm start` on local environment, `npm run lint-fix` runs before `npm run lint` . This will fix autofixable errors before running `lint`